### PR TITLE
Fix typos and add new flag to `create` command

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root=true
+
+[*.{js,jsx,ts,tsx}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/Developer.md
+++ b/Developer.md
@@ -42,7 +42,7 @@ The executable is generated to `doulevo.exe` in the current directory.
 
 Some commands for testing...
 
-### Creawting a project with a local plugin
+### Creating a project with a local plugin
 
 ```bash
 npx ts-node src/index.ts create test-project --force --local-plugin=./test-plugin --debug

--- a/README.MD
+++ b/README.MD
@@ -20,7 +20,7 @@ If you like the idea please star this repo.
 
 Doulevo needs your help! 
 
-Check out [the developer guide](Developer)
+Check out [the developer guide](Developer.md)
 
 Email ashley@codecapers.com.au to find out how you can help.
 
@@ -30,7 +30,7 @@ Doulevo is a work in progress, please email feedback to ashley@codecapers.com.au
 
 ## Write plugins
 
-Doulevo extensible by the community, [learn how to write a plugin](Plugin-developers-guide.md).
+Doulevo is extensible by the community, [learn how to write a plugin](Plugin-developers-guide.md).
 
 # Installation
 

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -52,7 +52,7 @@ export class CreateCommand implements IDoulevoCommand {
                 await this.fs.remove(projectPath);
             }
             else {
-                throw new Error(`Directory already exists at ${projectPath}, please delete the existing directory if you want to create a new project here`);
+                throw new Error(`Directory already exists at ${projectPath}, please delete the existing directory, or use the --force flag if you want to create a new project here`);
             }
         }
 

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -37,13 +37,34 @@ export class CreateCommand implements IDoulevoCommand {
     @InjectProperty(IProgressIndicator_id)
     progressIndicator!: IProgressIndicator;
 
+    displayHelp(): void {
+        this.log.info(`\nUsage: doulevo create [options] <project-dir>\n`);
+        this.log.info(`Creates a new Doulevo project at <project-dir>\n`);
+
+        this.log.info(`Options:`);
+
+        const optionPadding = 25;
+        this.log.info(" ".repeat(4) + "--force".padEnd(optionPadding) + "Deletes project directory if it already exists.");
+        this.log.info(" ".repeat(4) + "--local-plugin".padEnd(optionPadding) + "When set, Doulevo will create the project using the 'local' plugin from the specified location.");
+        this.log.info(" ".repeat(4) + "--plugin-url".padEnd(optionPadding) + "When set, Doulevo will create the project using the 'remote' plugin from the specified location.");
+        this.log.info(" ".repeat(4) + "--project-type".padEnd(optionPadding) + "When set, Doulevo will create the project using the default plugin for the specified project type.");
+        this.log.info(" ".repeat(4) + "--debug".padEnd(optionPadding) + "Logs command executions in the terminal.");
+        this.log.info(" ".repeat(4) + "--help".padEnd(optionPadding) + "Prints usage for this command.");
+    }
+
     async invoke(): Promise<void> {
-    
+
+        const isHelp = this.configuration.getArg<boolean>("help");
+
+        if (isHelp) {
+            return this.displayHelp();
+        }
+
         const projectDir = this.configuration.getMainCommand();
         if (!projectDir) {
             throw new Error(`Project directory not specified. Use "doulevo create <project-dir>`);
         }
-    
+
         const projectPath = joinPath(this.environment.cwd(), projectDir);
         const projectExists = await this.fs.exists(projectPath);
         if (projectExists) {

--- a/src/commands/down.ts
+++ b/src/commands/down.ts
@@ -26,7 +26,7 @@ export class DownCommand implements IDoulevoCommand {
     async invoke(): Promise<void> {
 
         //
-        // The build command operates against the current working directory.
+        // The down command operates against the current working directory.
         // Or the path can be set with the --project=<path> argument.
         //
         const projectPath = this.configuration.getArg("project") || this.environment.cwd();
@@ -44,9 +44,7 @@ export class DownCommand implements IDoulevoCommand {
         }
 
         //
-        // Do the build.
-        //
-        // TODO: Choose the current build plugin (eg "build/docker") based on project configuration.
+        // Stop the container
         //
         await this.docker.down(project, false);
     }

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -26,7 +26,7 @@ export class LogsCommand implements IDoulevoCommand {
     async invoke(): Promise<void> {
 
         //
-        // The build command operates against the current working directory.
+        // The log command operates against the current working directory.
         // Or the path can be set with the --project=<path> argument.
         //
         const projectPath = this.configuration.getArg("project") || this.environment.cwd();

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -26,7 +26,7 @@ export class UpCommand implements IDoulevoCommand {
     async invoke(): Promise<void> {
 
         //
-        // The build command operates against the current working directory.
+        // The up command operates against the current working directory.
         // Or the path can be set with the --project=<path> argument.
         //
         const projectPath = this.configuration.getArg("project") || this.environment.cwd();


### PR DESCRIPTION
Hey there :)

Thanks to your succinct video and article, I have a clear understanding of the vision for this project and I already love where it's going!

I'm starting off with super easy contributions :) Here are the changes introduced:
- Minor typo fixes and wording improvements In both code and comments
- New flag for the `create` command: `--help`. It can potentially become a default flag for all commands
- Introduce a `.editorconfig` file for people who have it supported in their editor

You call the new flag like so
`npx ts-node src/index.ts create --help`

Current output:
```

Usage: doulevo create [options] <project-dir>

Creates a new Doulevo project at <project-dir>

Options:
    --force                  Deletes project directory if it already exists.
    --local-plugin           When set, Doulevo will create the project using the 'local' plugin from the specified location.
    --plugin-url             When set, Doulevo will create the project using the 'remote' plugin from the specified location.
    --project-type           When set, Doulevo will create the project using the default plugin for the specified project type.
    --debug                  Logs command executions in the terminal.
    --help                   Prints usage for this command.

```

Let me know if that's something you care to add and feel free to update anything if it's not correct.